### PR TITLE
fixing error in Tornado.sol

### DIFF
--- a/finale/backend/contracts/Tornado.sol
+++ b/finale/backend/contracts/Tornado.sol
@@ -62,7 +62,7 @@ contract Tornado is ReentrancyGuard {
         uint256[2] memory ins;
         
         for(uint8 i = 0; i < treeLevel; i++){
-            lastLevelHash[treeLevel] = currentHash;
+            lastLevelHash[i] = currentHash;
 
             if(currentIdx % 2 == 0){
                 left = currentHash;


### PR DESCRIPTION
treeLevel is the total number of levels in the Merkle tree, whereas i is the current level being processed in the for-loop. So, lastLevelHash[i] should be updated with the hash value of the current node, not lastLevelHash[treeLevel].